### PR TITLE
Protect routes

### DIFF
--- a/src/features/common/Error/AuthError.tsx
+++ b/src/features/common/Error/AuthError.tsx
@@ -1,0 +1,12 @@
+import { signIn } from "next-auth/react";
+import Link from "next/link";
+
+export default function AuthError() {
+  return (
+    <div>
+      <h2>No estas autorizado a acceder a esta pagina</h2>
+      <button onClick={() => void signIn()}>Inicia sesion</button>
+      <Link href="/">O vuelve al inicio</Link>
+    </div>
+  );
+}

--- a/src/features/common/Error/QueryErrorBoundary.tsx
+++ b/src/features/common/Error/QueryErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import type { PropsWithChildren } from "react";
+import { type DefaultErrorShape } from "@trpc/server/dist/error/formatter";
+import { type typeToFlattenedError } from "zod";
+import { type TRPC_ERROR_CODE_KEY } from "@trpc/server/rpc";
+import AuthError from "./AuthError";
+
+type ErrorProps = {
+  error:
+    | (DefaultErrorShape["data"] & {
+        zodError: typeToFlattenedError<unknown, string> | null;
+      })
+    | null
+    | undefined;
+  refetch: () => Promise<unknown>;
+} & PropsWithChildren;
+
+const renderErrorData = (code: TRPC_ERROR_CODE_KEY) => {
+  // Agregar aqui errores a manejar
+  switch (code) {
+    case "UNAUTHORIZED":
+      return <AuthError />;
+    default:
+      return false;
+  }
+};
+
+export default function QueryErrorBoundary({
+  error,
+  refetch,
+  children,
+}: ErrorProps) {
+  if (error) {
+    const handleRefetch = () => {
+      refetch().catch((err) => console.error(err));
+    };
+    return (
+      renderErrorData(error.code) ?? (
+        <div>
+          <h2>Algo no funciono correctamente</h2>
+          <p>{error.code}</p>
+          <button onClick={handleRefetch}>Probar de nuevo</button>
+        </div>
+      )
+    );
+  } else return children;
+}

--- a/src/pages/space/[id]/index.tsx
+++ b/src/pages/space/[id]/index.tsx
@@ -10,10 +10,17 @@ import UbicationList from "~/features/ubication/UbicationList";
 import { api } from "~/utils/api";
 import Head from "next/head";
 
+import QueryErrorBoundary from "~/features/common/Error/QueryErrorBoundary";
+
 export default function Space() {
   const router = useRouter();
   const { id: spaceId } = router.query;
-  const { data: space, status } = api.space.getByid.useQuery(
+  const {
+    data: space,
+    status,
+    error,
+    refetch,
+  } = api.space.getByid.useQuery(
     { id: spaceId as string },
     {
       enabled: !!spaceId,
@@ -29,38 +36,40 @@ export default function Space() {
       <main className="h-screen bg-zinc-900 text-violet-300">
         <Container>
           {status == "loading" && <Loader />}
-          {status == "success" && space && (
-            <>
-              <div className="mb-4 flex w-full items-center justify-center gap-2 text-2xl font-bold text-gray-300">
-                <ContainerIcon />
-                <h1>{space.name}</h1>
-              </div>
-              <Link
-                href="/"
-                className="mb-4 w-fit text-gray-400 hover:text-gray-600"
-              >
-                Volver al listado de espacios
-              </Link>
-              {space.ubications.length > 0 ? (
-                <UbicationList
-                  ubications={space?.ubications}
-                  spaceId={spaceId as string}
-                />
-              ) : (
-                <div className="mt-8 flex flex-col items-center gap-6">
-                  <h2 className="text-center text-xl font-bold text-gray-600">
-                    No tienes ubicaciones registradas
-                  </h2>
-                  <Link
-                    href={`/space/${spaceId?.toString()}/add-ubication`}
-                    className="w-fit rounded-md bg-cyan-600 p-4 text-xl font-bold text-gray-100"
-                  >
-                    <h3>Crea la primera</h3>
-                  </Link>
+          <QueryErrorBoundary error={error?.data} refetch={refetch}>
+            {status == "success" && space && (
+              <>
+                <div className="mb-4 flex w-full items-center justify-center gap-2 text-2xl font-bold text-gray-300">
+                  <ContainerIcon />
+                  <h1>{space.name}</h1>
                 </div>
-              )}
-            </>
-          )}
+                <Link
+                  href="/"
+                  className="mb-4 w-fit text-gray-400 hover:text-gray-600"
+                >
+                  Volver al listado de espacios
+                </Link>
+                {space.ubications.length > 0 ? (
+                  <UbicationList
+                    ubications={space?.ubications}
+                    spaceId={spaceId as string}
+                  />
+                ) : (
+                  <div className="mt-8 flex flex-col items-center gap-6">
+                    <h2 className="text-center text-xl font-bold text-gray-600">
+                      No tienes ubicaciones registradas
+                    </h2>
+                    <Link
+                      href={`/space/${spaceId?.toString()}/add-ubication`}
+                      className="w-fit rounded-md bg-cyan-600 p-4 text-xl font-bold text-gray-100"
+                    >
+                      <h3>Crea la primera</h3>
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </QueryErrorBoundary>
         </Container>
       </main>
     </>

--- a/src/pages/ubication/[id]/index.tsx
+++ b/src/pages/ubication/[id]/index.tsx
@@ -5,13 +5,14 @@ import Loader from "~/features/common/Loader";
 
 import { api } from "~/utils/api";
 import Container from "~/features/common/Container";
-import { Error } from "~/features/common/Form/Error";
+import { Error as FormError } from "~/features/common/Form/Error";
+import QueryErrorBoundary from "~/features/common/Error/QueryErrorBoundary";
 
 export default function UbicationPage() {
   const router = useRouter();
   const { id } = router.query;
 
-  const { data, status } = api.ubication.getById.useQuery(
+  const { data, status, error, refetch } = api.ubication.getById.useQuery(
     { id: id?.toString() ?? "" },
     { enabled: !!id },
   );
@@ -26,13 +27,15 @@ export default function UbicationPage() {
         }
       case "error":
       default:
-        return <Error />;
+        return <FormError />;
     }
   };
   return (
     <>
       <main>
-        <Container>{renderData()}</Container>
+        <QueryErrorBoundary error={error?.data} refetch={refetch}>
+          <Container>{renderData()}</Container>
+        </QueryErrorBoundary>
       </main>
     </>
   );

--- a/src/server/api/routers/food.ts
+++ b/src/server/api/routers/food.ts
@@ -1,6 +1,10 @@
 import { FREEZE_STATES } from "~/features/food/components/Food/constants";
 import { calculateFreezerTime } from "~/features/food/utils/calculateFreezerTime";
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  createTRPCRouter,
+  publicProcedure,
+  protectedProcedure,
+} from "~/server/api/trpc";
 
 import {
   getFoods,
@@ -12,25 +16,27 @@ import {
 } from "~/utils/schemas/food";
 
 export const foodRouter = createTRPCRouter({
-  create: publicProcedure.input(createFood).mutation(async ({ input, ctx }) => {
-    const { isFreezer } = await ctx.db.ubication.findUniqueOrThrow({
-      where: { id: input.ubicationId },
-      select: { isFreezer: true },
-    });
-    return ctx.db.food.create({
-      data: {
-        ...input,
-        ammount: parseFloat(input.ammount),
-        storedAt: new Date(),
-        freezedAt: isFreezer ? new Date() : undefined,
-        description: input.description ?? "",
-      },
-    });
-  }),
+  create: protectedProcedure
+    .input(createFood)
+    .mutation(async ({ input, ctx }) => {
+      const { isFreezer } = await ctx.db.ubication.findUniqueOrThrow({
+        where: { id: input.ubicationId },
+        select: { isFreezer: true },
+      });
+      return ctx.db.food.create({
+        data: {
+          ...input,
+          ammount: parseFloat(input.ammount),
+          storedAt: new Date(),
+          freezedAt: isFreezer ? new Date() : undefined,
+          description: input.description ?? "",
+        },
+      });
+    }),
 
   getByid: publicProcedure.input(getFoodById).query(({ input, ctx }) => null),
 
-  getFromUbication: publicProcedure.input(getFoods).query(({ input, ctx }) =>
+  getFromUbication: protectedProcedure.input(getFoods).query(({ input, ctx }) =>
     ctx.db.food.findMany({
       where: {
         ubicationId: input.ubicationId,
@@ -42,36 +48,38 @@ export const foodRouter = createTRPCRouter({
     }),
   ),
 
-  consume: publicProcedure.input(consume).mutation(async ({ input, ctx }) => {
-    const updated = await ctx.db.food.update({
-      where: { id: input.id, ammount: { gte: input.ammount } },
-      data: {
-        ammount: {
-          decrement: input.ammount,
-        },
-      },
-    });
-    if (updated.ammount == 0) {
-      await ctx.db.food.update({
-        where: { id: updated.id },
+  consume: protectedProcedure
+    .input(consume)
+    .mutation(async ({ input, ctx }) => {
+      const updated = await ctx.db.food.update({
+        where: { id: input.id, ammount: { gte: input.ammount } },
         data: {
-          usedAt: new Date(),
+          ammount: {
+            decrement: input.ammount,
+          },
         },
       });
-    } else {
-      await ctx.db.food.create({
-        data: {
-          ...updated,
-          id: undefined,
-          ammount: 0,
-          usedAt: new Date(),
-        },
-      });
-    }
-    return true;
-  }),
+      if (updated.ammount == 0) {
+        await ctx.db.food.update({
+          where: { id: updated.id },
+          data: {
+            usedAt: new Date(),
+          },
+        });
+      } else {
+        await ctx.db.food.create({
+          data: {
+            ...updated,
+            id: undefined,
+            ammount: 0,
+            usedAt: new Date(),
+          },
+        });
+      }
+      return true;
+    }),
 
-  editFoodData: publicProcedure.input(editFood).mutation(({ ctx, input }) =>
+  editFoodData: protectedProcedure.input(editFood).mutation(({ ctx, input }) =>
     ctx.db.food.update({
       where: { id: input.id },
       data: {
@@ -83,7 +91,7 @@ export const foodRouter = createTRPCRouter({
     }),
   ),
 
-  changeUbication: publicProcedure
+  changeUbication: protectedProcedure
     .input(changeUbicationSchema)
     .mutation(async ({ ctx, input }) => {
       const { freezedAt, type: foodType } = await ctx.db.food.findUniqueOrThrow(
@@ -117,7 +125,7 @@ export const foodRouter = createTRPCRouter({
       });
     }),
 
-  deleteById: publicProcedure
+  deleteById: protectedProcedure
     .input(getFoodById)
     .mutation(({ ctx, input }) =>
       ctx.db.food.delete({ where: { id: input.id } }),

--- a/src/server/api/routers/space.ts
+++ b/src/server/api/routers/space.ts
@@ -1,21 +1,31 @@
 import { createSpace, getSpace } from "~/utils/schemas/space";
 
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "~/server/api/trpc";
 
 export const spaceRouter = createTRPCRouter({
-  create: publicProcedure.input(createSpace).mutation(({ input, ctx }) => ctx.db.space.create({ data: { name: input.name } })),
+  create: publicProcedure
+    .input(createSpace)
+    .mutation(({ input, ctx }) =>
+      ctx.db.space.create({ data: { name: input.name } }),
+    ),
 
-  getAll: publicProcedure.query(({ ctx }) => 
+  getAll: publicProcedure.query(({ ctx }) =>
     // TODO: Change to get only by user (when some kind of auth is implemented)
-     ctx.db.space.findMany()
+    ctx.db.space.findMany(),
   ),
 
-  getByid: publicProcedure.input(getSpace).query(({ input, ctx }) => ctx.db.space.findUnique({
+  getByid: protectedProcedure.input(getSpace).query(({ input, ctx }) =>
+    ctx.db.space.findUnique({
       where: {
         id: input.id,
       },
       include: {
         ubications: true,
       },
-    })),
+    }),
+  ),
 });

--- a/src/server/api/routers/space.ts
+++ b/src/server/api/routers/space.ts
@@ -7,7 +7,7 @@ import {
 } from "~/server/api/trpc";
 
 export const spaceRouter = createTRPCRouter({
-  create: publicProcedure
+  create: protectedProcedure
     .input(createSpace)
     .mutation(({ input, ctx }) =>
       ctx.db.space.create({ data: { name: input.name } }),

--- a/src/server/api/routers/ubication.ts
+++ b/src/server/api/routers/ubication.ts
@@ -1,25 +1,27 @@
-import { createTRPCRouter, publicProcedure } from "../trpc";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { createUbication, getUbicationById } from "~/utils/schemas/ubication";
 
 export const ubicationRouter = createTRPCRouter({
-  getById: publicProcedure
+  getById: protectedProcedure
     .input(getUbicationById)
     .query(({ input, ctx }) =>
       ctx.db.ubication.findUnique({ where: { id: input.id } }),
     ),
 
-  getOthers: publicProcedure.input(getUbicationById).query(({ input, ctx }) =>
-    ctx.db.ubication.findMany({
-      where: { id: { not: input.id } },
-      select: {
-        name: true,
-        id: true,
-        isFreezer: true,
-      },
-    }),
-  ),
+  getOthers: protectedProcedure
+    .input(getUbicationById)
+    .query(({ input, ctx }) =>
+      ctx.db.ubication.findMany({
+        where: { id: { not: input.id } },
+        select: {
+          name: true,
+          id: true,
+          isFreezer: true,
+        },
+      }),
+    ),
 
-  create: publicProcedure.input(createUbication).mutation(({ input, ctx }) =>
+  create: protectedProcedure.input(createUbication).mutation(({ input, ctx }) =>
     ctx.db.ubication.create({
       data: {
         ...input,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,6 +3854,13 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Feats

* Uso de **protectedProcedures** --> El servidor da error cuando no hay un usuario loggeado
* Componente **QueryErrorBoundary** --> Se le pasan los parametros `error` y `refetch` de un useQuery / useMutation. Con eso si falla devuelve un componente de error en lugar de lo que contiene.
* Componente **AuthError** --> Muestra un mensaje basico de que no esta autorizado y ofrece ir al login (que lo devuelve a la pagina donde estaba)
* **queryClientConfig** en el archivo de configuracion de la api --> Agrego un parametro para que no reintente hacer las queries cuando el error es de falta de permisos

## Preguntas

* Quedo un poco complejo el tipado de los errores, hay mucha data confusa en la documentacion. Se podra simplificar?
* Hacer el refetch opcional? Lo vi en un ejemplo y me parecio que estaba bueno como para atajar si hay otro tipo de error, pero bueno, medio edge case por ahora.. quizas se pueda sacar asi usamos mas tranquilos ese componente.

## Derivaciones

* Agregar el comportamiento especifico cuando se pida lo relevante a usuarios en concreto
* Agregar mas defaults al queryClientConfig? Por ejemplo sacar todos los refetchOnWindowsFocus? limitar la cantidad de retrys?

## Para mejorar

* estilos de los componentes de error
* Ver que los errores no siempre abarquen la pagina completa, que se pueda dar un render parcial igual