### PR TITLE
Agregado de entidades de Autenticacion a la DB

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,10 +14,20 @@ datasource db {
     url      = env("DATABASE_URL")
 }
 
+enum SharedConfig {
+    PRIVATE
+    INVITATION
+    PUBLIC_LINK
+}
+
 model Space {
-    id         String      @id @default(cuid())
-    name       String
-    ubications Ubication[]
+    id           String       @id @default(cuid())
+    name         String
+    ubications   Ubication[]
+    owner        User         @relation(fields: [ownerId], references: [id], name: "ownership")
+    ownerId      String
+    users        User[]
+    sharedConfig SharedConfig @default(PRIVATE)
 }
 
 model Ubication {
@@ -85,6 +95,8 @@ model User {
     image         String?
     accounts      Account[]
     sessions      Session[]
+    ownedSpaces   Space[]   @relation(name: "ownership")
+    sharedSpaces  Space[]
 }
 
 model VerificationToken {


### PR DESCRIPTION
## Warning ⚠️⚠️
### Toque los esquemas de Prisma! 
Hay que correr un ```db:push``` y se va a borrar toda la data de la DB

## Feats
- Space ahora tiene:
   - **owner**: User
   - **ownerId**: string
   - **users**: User[] (invitados vendrian a ser)
   - **sharedConfig**: PRIVATE (default) | INVITATION | PUBLIC_LINK --> Pensaba que podemos tener estas tres configs donde
      - **PRIVATE**: no la puede ver/usar nadie mas
      - **INVITATION**: solo aquellas personas que se inviten especificamente (faltaria una entidad Invitation o algo asi para implementar esto)
      - **PUBLIC_LINK**: quienes tengan el link pueden ver/editar
- User ahora tiene:
  - ownedSpaces: Space[]
  - sharedSpaces: Space[] (donde es invitado)

- Edite en el router de space dos procedures:
   - **create**: agrega el userId tomado de la sesion (google) como ownerId
   - **getAll**: trae los que tienen por ownerId al id de usuario Y los que incluyan all id de usuario en su lista de users

## A considerar
- Quizas sea mas practico traer los ownedSpaces y sharedSpaces desde el usuario
- Nos sirve distinguirlos en el front? Se pueden mandar por separado en un objeto o filtrarlos en el cliente
- Habria que enforzar todos los checks de ("sos el owner" or "estas en la lista de usuarios") para cada ruta protegida. Me pregunto: sera mejor no distinguir al owner y meter todo en una unica lista y punto?