### PR TITLE
add food history EP in space router

### DIFF
--- a/src/pages/space/[id]/index.tsx
+++ b/src/pages/space/[id]/index.tsx
@@ -25,6 +25,16 @@ export default function Space() {
     },
   );
 
+  const { data: history } = api.space.getHistory.useQuery(
+    { id: spaceId?.toString() ?? "" },
+    {
+      enabled: !!spaceId,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  console.log(history);
+
   return (
     <PageLayout
       headTitle={space ? `Espacio - ${space?.name}` : "Freezados BARF"}

--- a/src/server/api/routers/space.ts
+++ b/src/server/api/routers/space.ts
@@ -118,4 +118,20 @@ export const spaceRouter = createTRPCRouter({
         },
       }),
     ),
+
+  getHistory: protectedProcedure.input(getSpace).query(({ ctx, input }) =>
+    ctx.db.food.findMany({
+      where: {
+        ubication: {
+          spaceId: input.id,
+        },
+        usedAt: {
+          not: null,
+        },
+      },
+      orderBy: {
+        storedAt: "desc",
+      },
+    }),
+  ),
 });


### PR DESCRIPTION
- api.space.getHistory devuelve un Food[] con los alimentos consumidos en orden cronologico (nuevos primero)
- Por ahora eso es lo unico que devuelve el EP. Lo puse en el router de space por si despues queremos devolver otra info, separarlo por ubication, tener otro tipo de data etc.